### PR TITLE
update test_clusters and test_isochrone

### DIFF
--- a/iggyapi/api.py
+++ b/iggyapi/api.py
@@ -275,7 +275,6 @@ class IggyAPI():
 
         :return: gpd.GeoDataFrame or dict
         """
-        raw_response = options.get("raw", False)
         if raw_response:
             return self.enrich("clusters", options)
         else:

--- a/tests/test_clusters.py
+++ b/tests/test_clusters.py
@@ -186,4 +186,12 @@ def test_cluster_endpoint():
     with requests_mock.Mocker() as m:
         m.get("https://api.askiggy.com/v1/clusters?latitude=44.976469&longitude=-93.271205&category=restaurants&within_miles=3",
               json=cluster_response)
-        assert curr_api.clusters(cluster_object) == cluster_response
+        assert curr_api.clusters(cluster_object, raw_response=True) == cluster_response
+
+def test_cluster_gdf():
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://api.askiggy.com/v1/clusters?latitude=44.976469&longitude=-93.271205&category=restaurants&within_miles=3",
+            json=cluster_response)
+        gdf = curr_api.clusters(cluster_object)
+        assert gdf.shape[0] == len(cluster_response['clusters'])

--- a/tests/test_isochrone.py
+++ b/tests/test_isochrone.py
@@ -54,4 +54,10 @@ response = {
 def test_isochrone():
     with requests_mock.Mocker() as m:
         m.get("https://api.askiggy.com/v1/isochrone?lat=44.976469&lng=-93.271205&time_limit_minutes=1&mode=car", json=response)
-        assert curr_api.isochrone(isochrone_object) == response
+        assert curr_api.isochrone(isochrone_object, raw_response=True) == response
+
+def test_isochrone_gdf():
+    with requests_mock.Mocker() as m:
+        m.get("https://api.askiggy.com/v1/isochrone?lat=44.976469&lng=-93.271205&time_limit_minutes=1&mode=car", json=response)
+        gdf = curr_api.isochrone(isochrone_object)
+        assert gdf.shape[0] == 1


### PR DESCRIPTION
## Summary

Tests `test_clusters` and `test_isochrone` were failing due to new default response as GeoDataFrame

## Changes

Updated these tests to add param for `raw_response=True`.

Added additional tests to verify shape of returned GeoDataFrame.